### PR TITLE
- #12 if css method used as a getter just return the current style confi...

### DIFF
--- a/plugins/controls/src/actionscript/org/flowplayer/controls/Controls.as
+++ b/plugins/controls/src/actionscript/org/flowplayer/controls/Controls.as
@@ -295,6 +295,9 @@ package org.flowplayer.controls {
          * @inheritDoc
          */
         override public function css(styleProps:Object = null):Object {
+            //#12 if css method used as a getter just return the current style config.
+            if (!styleProps) return _config.style;
+
             var result:Object = super.css(styleProps);
 
 			if ( _controlBarMover ) {

--- a/plugins/viralvideos/README.txt
+++ b/plugins/viralvideos/README.txt
@@ -11,6 +11,7 @@ sVersion history:
 - #618 if we have output from the request either parse as json or if the script returns html it is success. If we have no output the send is successful.
 - #618 refactored server return to not require json output anymore and return success. Return success on all request errors with logging, return success on token error with logging. Added 3 new configurable email labels,
 "success", "required", "sending"
+- #12 if css method used as a getter just return the current style config.
 
 3.2.11
 ------


### PR DESCRIPTION
little issue that came up when the css method is used as a getter due to a recent change, with no argument config it should just return the style config. 
