### PR TITLE
Issue #22: ipad: reinstate validExtensions variable

### DIFF
--- a/js-plugins/ipad/flowplayer.ipad.js
+++ b/js-plugins/ipad/flowplayer.ipad.js
@@ -96,7 +96,7 @@ $f.addPlugin("ipad", function(options) {
 
 	extend(opts, options);
 
-	var validExtensions = validExtensions ? new RegExp('^\.(' + opts.validExtensions + ')$', 'i') : null;
+	var validExtensions = opts.validExtensions ? new RegExp('^\.(' + opts.validExtensions + ')$', 'i') : null;
 	var posterExtensions = new RegExp('^\.(' + opts.posterExtensions + ')$', 'i');
 
 	// some util funcs


### PR DESCRIPTION
http://code.google.com/p/flowplayer-plugins/source/detail?r=1968
accidentally set validExtensions always to null, thus disabling
all file suffix checking and also preventing poster creation by
playlist based splash image setups.
