### PR TITLE
Issue #21: consistent clip url queries in json config and api

### DIFF
--- a/core/src/javascript/flowplayer.js/flowplayer-src.js
+++ b/core/src/javascript/flowplayer.js/flowplayer-src.js
@@ -138,6 +138,10 @@
 		to[evt].push(fn);
 	}
 
+	// escape & and = in config written into flashvars (issue #21)
+	function queryescape(url) {
+		return url.replace(/&amp;/g, '%26').replace(/&/g, '%26').replace(/=/g, '%3D');
+	}
 
 	// generates an unique id
    function makeId() {
@@ -977,6 +981,10 @@ function Player(wrapper, params, conf) {
 			conf.clip.url = wrapper.getAttribute("href", 2);
 		}
 
+		if (conf.clip.url) {
+			conf.clip.url = queryescape(conf.clip.url);
+		}
+
 		commonClip = new Clip(conf.clip, -1, self);
 
 		// playlist
@@ -991,6 +999,10 @@ function Player(wrapper, params, conf) {
 			/* sometimes clip is given as array. this is not accepted. */
 			if (typeof clip == 'object' && clip.length) {
 				clip = {url: "" + clip};
+			}
+
+			if (clip.url) {
+				clip.url = queryescape(clip.url);
 			}
 
 			// populate common clip properties to each clip


### PR DESCRIPTION
This allows to give unescaped ampersands and equal signs in the json
configuration or parsed anchors of clip urls.

They must be escaped because they are written as flashvars into the
generated object.

Whereas api methods, like play(url), needed unescaped urls.

This change tries to be very defensive and only addresses clip urls
to avoid the issues encountered in 3.2.8 with point blank escaping the
entire configuration. Note that the substitution also touches the query
part of an url only as & and = are only allowed there.

Use case: amazon cloudfront signed urls.

See also: http://flash.flowplayer.org/forum/8/103438/

TODO: look for other occurences where this can be done in a safe way,
like for the queryString paramter of the pseudostreaming plugin.
