### PR TITLE
api: handle Flash detection in Safari 6 (#167)

### DIFF
--- a/core/src/javascript/flashembed.js
+++ b/core/src/javascript/flashembed.js
@@ -88,10 +88,14 @@
 		conf: GLOBAL_OPTS,
 
 		getVersion: function()  {
-			var fo, ver;
+			var fo, ver, plugin;
 
 			try {
-				ver = navigator.plugins["Shockwave Flash"].description.slice(16);
+				plugin = navigator.plugins["Shockwave Flash"];
+				// Safari 6 reports version even when disabled
+				// but [0, 0] should be returned (#167)
+				if (plugin[0].enabledPlugin != null)
+					ver = plugin.description.slice(16);
 			} catch(e) {
 
 				try  {


### PR DESCRIPTION
Safari 6 reports the installed Flash version even when the plugin is
disabled, thus for instance not triggering expressInstall.
Make sure to return Flash version only when Flash plugin is actually
enabled.
