### PR TITLE
Mend license headers in flowplayer-src and flashembed (#186)

### DIFF
--- a/core/src/javascript/flashembed.js
+++ b/core/src/javascript/flashembed.js
@@ -1,13 +1,7 @@
 /**
- * @license
- * jQuery Tools @VERSION / Flashembed - New wave Flash embedding
- *
  * NO COPYRIGHTS OR LICENSES. DO WHAT YOU LIKE.
  *
  * http://flowplayer.org/tools/toolbox/flashembed.html
- *
- * Since : March 2008
- * Date  : @DATE
  */
 !function() {
 

--- a/core/src/javascript/flowplayer.js/flowplayer-src.js
+++ b/core/src/javascript/flowplayer.js/flowplayer-src.js
@@ -1,7 +1,7 @@
 /*!
  * flowplayer.js The Flowplayer API
  *
- * Copyright 2009-2011 Flowplayer Oy
+ * Copyright 2009-2013 Flowplayer Oy
  *
  * This file is part of Flowplayer.
  *


### PR DESCRIPTION
This is still not ideal. The build script should:
- add release version and number to all published JS files
  https://github.com/flowplayer/flash-build/issues/7
- create and publish the unminified api
  https://github.com/flowplayer/flash-build/issues/6
