### PR TITLE
Get the correct PlayButtonOverlayView object for bufferAnimate

### DIFF
--- a/core/src/actionscript/org/flowplayer/view/FlowplayerBase.as
+++ b/core/src/actionscript/org/flowplayer/view/FlowplayerBase.as
@@ -333,7 +333,7 @@ package org.flowplayer.view {
         }
 
         public function bufferAnimate(enable:Boolean = true):void {
-            var playBtn:Object = playButtonOverlay.getDisplayObject();
+			var playBtn:Object = _pluginRegistry.getPlugin("play").pluginObject;
             if (enable) {
                 playBtn.startBuffering();
             } else {


### PR DESCRIPTION
For bufferAnimate() to work, it needs to call startBuffering() and
stopBuffering() on the right playBtn object. Tested the compiled swc on
a custom player page. Please verify on your end.
