### PR TITLE
Removed recurcive stop method from WaitingState.

### DIFF
--- a/core/src/actionscript/org/flowplayer/controller/WaitingState.as
+++ b/core/src/actionscript/org/flowplayer/controller/WaitingState.as
@@ -48,9 +48,6 @@ import org.flowplayer.model.ClipEventType;
 		}
 
         override internal function stop(closeStreamAndConnection:Boolean = false, silent:Boolean = false):void {
-            if (closeStreamAndConnection) {
-                stop(true);
-            }
         }
 
 		internal override function startBuffering():void {

--- a/core/src/actionscript/org/flowplayer/view/AnimationEngine.as
+++ b/core/src/actionscript/org/flowplayer/view/AnimationEngine.as
@@ -342,7 +342,7 @@ package org.flowplayer.view {
                 playable.addEventListener(GoEvent.UPDATE, 
                     function(event:GoEvent):void {
                         updateCallback(view);
-                }, false, 0, true);
+                }, false, 0, false);
             }
 
 			playable.start();


### PR DESCRIPTION
When PlayListController is in WaitingState and we are trying to play a clip via javascript like:

```
player.fp_play(clip_descriptor)
```

WaitingState.stop method is called, so execution context waits for infinite recursion to stop.

I can't say if this method was needed for some purposes, because I could not find change history in google code. At least, I did not find any direct calls to this method in code. So, I left it empty.
