### PR TITLE
Issues with class metadata

### DIFF
--- a/core/src/actionscript/org/flowplayer/config/ExternalInterfaceHelper.as
+++ b/core/src/actionscript/org/flowplayer/config/ExternalInterfaceHelper.as
@@ -17,7 +17,8 @@
  */
 
 package org.flowplayer.config {
-	import flash.external.ExternalInterface;
+import flash.debugger.enterDebugger;
+import flash.external.ExternalInterface;
 	import flash.utils.describeType;
 	import flash.utils.getDefinitionByName;
 	import flash.utils.getQualifiedClassName;
@@ -36,13 +37,13 @@ package org.flowplayer.config {
 		public static function initializeInterface(callable:Callable, plugin:Object):void {
 			if (!ExternalInterface.available) return;
 			var xml:XML = describeType(plugin);
-			
-			var exposed:XMLList = xml.*.(hasOwnProperty("metadata") && metadata.@name=="External");
-			log.info("Number of exposed methods and accessors: " + exposed.length());
-			for each (var exposedNode:XML in exposed) {
-				log.debug("processing exposed method or accessor " + exposedNode);
-				addMethods(callable, exposedNode, plugin);
-			}
+
+            for each(var node:XML in xml.*) {
+                if(node.hasOwnProperty('metadata') && node.metadata.attributes().contains("External")) {
+                    log.debug("processing exposed method or accessor " + node);
+                    addMethods(callable, node, plugin);
+                }
+            }
 		}
 		
 		private static function addMethods(callable:Callable, exposedNode:XML, plugin:Object):void {

--- a/core/src/actionscript/org/flowplayer/util/ObjectConverter.as
+++ b/core/src/actionscript/org/flowplayer/util/ObjectConverter.as
@@ -1,6 +1,7 @@
 package org.flowplayer.util {
 
-    import flash.utils.describeType;
+import flash.debugger.enterDebugger;
+import flash.utils.describeType;
 
     import org.flowplayer.model.Extendable;
 
@@ -54,18 +55,20 @@ package org.flowplayer.util {
 			var obj:Object = new Object();
 			var classInfo:XML = describeType(o);
 			log.debug("classInfo : " + classInfo.@name.toString());
-			
 			if (classInfo.@name.toString() == "Object") {
                 copyProps(o, obj);
 			} else { // o is a class instance
 				// Loop over all of the *annotated* variables and accessors in the class and convert
-				var exposed:XMLList = classInfo.*.(hasOwnProperty("metadata") && metadata.@name=="Value");
-				for each (var v:XML in exposed) {
-					if (o[v.@name] != null) {
-						var key2:String = v.metadata.arg.@key == "name" ? v.metadata.arg.@value : v.@name.toString();
-						obj[key2] = process(o[v.@name]);
-					}
-				}
+                for each(var v:XML in classInfo.*) {
+                    if (v.hasOwnProperty("metadata") &&
+                        v.metadata.attributes().contains("Value") &&
+                        o[v.@name] != null)
+                    {
+                        var key2:String = v.metadata.arg.@key == "name" ? v.metadata.arg.@value : v.@name.toString();
+                        obj[key2] = process(o[v.@name]);
+                    }
+                }
+
                 if (o is Extendable) {
                     copyProps(Extendable(o).customProperties, obj);
                 }

--- a/core/src/javascript/flowplayer.js/flowplayer-src.js
+++ b/core/src/javascript/flowplayer.js/flowplayer-src.js
@@ -430,14 +430,14 @@
 
             // update plugins properties & methods
             if (evt == 'onUpdate') {
-               var json = player._api().fp_getPlugin(name);
-					if (!json) { return;	}
+               var api = player._api();
+               var json = api.fp_getPlugin(name);
+               if (!json) return;
 
                extend(self, json);
                delete self.methods;
-
                if (!hasMethods) {
-                  each(json.methods, function() {
+                  each(json.methods || json.methodNames, function() {
                      var method = "" + this;
 
                      self[method] = function() {


### PR DESCRIPTION
Fixes issues with class metadata causing various annotations to go unprocessed (External and Value for example). Also fix for not being able to read plugin methods from javascript.

I was having an issue with multiple "metadata" elements in the class metadata being generated on my machine. This may be due to debug being enabled.
