### PR TITLE
js api: escape & and = in all string config values (#260)

### DIFF
--- a/core/src/javascript/flowplayer.js/flowplayer-src.js
+++ b/core/src/javascript/flowplayer.js/flowplayer-src.js
@@ -141,7 +141,7 @@
     // because & and = cannot be written into the Flash object on the page
     function queryescape(obj) {
         if (typeof obj === "string") {
-            return obj.replace(/&amp;/g, '%26').replace(/&/g, '%26').replace(/=/g, '%3D');
+            return obj.replace(/&(amp;)?/g, '%26').replace(/=/g, '%3D');
         } else if (typeof obj === "object") {
             if (obj.length) {
                 each(obj, function (i, item) {


### PR DESCRIPTION
Ampersands and equal signs in the static configuration break setups
completely, even where they are perfectly legal, like in urls.
Instead of trying to catch all properties which may be fed an url, apply
reduced escaping to all string values in the configuration.

This will not touch any dynamic settings where writing to the Flash
object on the html page is not involved, like
clip.update({url: "yadda?x=y"}) which is not an issue.

It is also not the same as the point blank url encoding which was tried
in 3.2.8 to detrimental effect, and therefore had to be backed out.
